### PR TITLE
Add requirements regarding OS and disk storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Installation (Install Script)
 =============================
 
 * Create and configure a new Windows Virtual Machine
+  * FLARE VM is designed to be installed on Windows 7 Service Pack 1 or newer
+  * Allow for a total of 50-60 GB disk storage (including OS)
   * Ensure VM is updated completely. You may have to check for updates, reboot, and check again until no more remain 
 * Take a snapshot of your machine!
 * Download and copy `install.ps1` on your newly configured machine. 


### PR DESCRIPTION
Submitting this PR because I failed to install FlareVM using the [free Microsoft IE/Edge VMs](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/) with their standard 40 GB disk image until I realized I needed to allocate more storage space. Hopefully this hint in the README.md will allow avoiding this pitfall.